### PR TITLE
changed default dir to point to output from ofp, which was changed to…

### DIFF
--- a/ncf2cbh/ncf2cbh.py
+++ b/ncf2cbh/ncf2cbh.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
         print('setting dir = ' + sys.argv[1])
         dir = sys.argv[1]
     else:
-        dir='/var/lib/nhm/ofp/Output/'
+        dir='/var/lib/nhm/NHM-PRMS_CONUS/input/'
 
     nc_fn = dir + 'climate_'+str(datetime.datetime.now().strftime('%Y_%m_%d'))+'.nc'
 


### PR DESCRIPTION
Changed default dir in ndf2cbh to point to same output dir that ofp in docker-images point to, which is now the directory prms looks for these files.